### PR TITLE
Cleaning

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
+CFLAGS := -Wall -pedantic -std=c99
 
 test: readline.c test.c
-	@$(CC) $^ -std=c99 -o $@
+	@$(CC) $^ $(CFLAGS) -o $@
 	@./test
 
 .PHONY: test

--- a/README.md
+++ b/README.md
@@ -46,24 +46,32 @@ API
 /*
  * Create a context of readline from a buffer
  */
-
 readline_t *
 readline_new(char * buffer);
 
 /*
  * Get the next line of the context
  */
-
 char *
 readline_next(readline_t * rl);
 
 /*
  * Get last line of a buffer, ignoring any context of readline
  */
+char *
+readline_last_from_rl(readline_t * rl);
 
+/*
+ * Get the last line directly buffer
+ */
 char *
 readline_last(char * buffer);
 
+/*
+ * free the object
+ */
+void
+readline_free(readline_t * rl);
 ```
 
 

--- a/readline.h
+++ b/readline.h
@@ -21,35 +21,30 @@ typedef struct readline_s {
 /*
  * create a new readline struct
  */
-
 readline_t *
 readline_new(char * buffer);
 
 /*
  * next cursor
  */
-
 char *
 readline_next(readline_t * rl);
 
 /*
  * get the last line directly
  */
-
 char *
 readline_last_from_rl(readline_t * rl);
 
 /*
  * get the last line from buffer
  */
-
-inline char *
+char *
 readline_last(char * buffer);
 
 /*
  * free the object
  */
-
 void
 readline_free(readline_t * rl);
 

--- a/readline.h
+++ b/readline.h
@@ -31,13 +31,13 @@ char *
 readline_next(readline_t * rl);
 
 /*
- * get the last line directly
+ * Get last line of a buffer, ignoring any context of readline
  */
 char *
 readline_last_from_rl(readline_t * rl);
 
 /*
- * get the last line from buffer
+ * Get the last line directly buffer
  */
 char *
 readline_last(char * buffer);

--- a/test.c
+++ b/test.c
@@ -8,7 +8,9 @@
 #define test_start() \
   printf("\n================\n")  \
 
-
+/*
+ * Reads two lines
+ */
 void
 test_readline_simple() {
 
@@ -25,10 +27,15 @@ test_readline_simple() {
     count++;
     printf("line: %s\n", line);
   }
+
   assert(count == 2);
+  printf("\t OK\n");
 }
 
-void 
+/*
+ * Reads 3 lines, including an empty line
+ */
+void
 test_readline_empty_line() {
   test_start();
   char * buf = "" \
@@ -44,8 +51,14 @@ test_readline_empty_line() {
     count++;
     printf("line: %s\n", line);
   }
+
+  assert(count == 3);
+  printf("\t OK\n");
 }
 
+/*
+ * Reads the last line
+ */
 void
 test_readline_last_line() {
 
@@ -62,10 +75,16 @@ test_readline_last_line() {
   while ((line = (readline_next(rl))) != NULL) {
     count++;
     printf("line: %s\n", line);
+    assert(count <= 3);
   }
+
   assert(count == 3);
+  printf("\t OK\n");
 }
 
+/*
+ * Reads the last that isn't empty
+ */
 void
 test_readline_last_empty_line() {
 
@@ -83,9 +102,14 @@ test_readline_last_empty_line() {
     count++;
     printf("line: %s\n", line);
   }
+
   assert(count == 2);
+  printf("\t OK\n");
 }
 
+/*
+ * Reads the last line
+ */
 void
 test_readline_last() {
 
@@ -97,9 +121,14 @@ test_readline_last() {
 
   char * last = readline_last(buf);
   printf("last: %s\n", last);
+
   assert(strcmp("javascript", last) == 0);
+  printf("\t OK\n");
 }
 
+/*
+ * Reads the last line without \n
+ */
 void
 test_readline_last_without_10() {
 
@@ -111,10 +140,13 @@ test_readline_last_without_10() {
 
   char * last = readline_last(buf);
   printf("last: %s\n", last);
+
   assert(strcmp("javascript", last) == 0);
+  printf("\t OK\n");
 }
 
-int 
+
+int
 main() {
 
   /* next func */


### PR DESCRIPTION
```
- No more warning about a false inlined function
- Added asserts
- Removed unnecessary memset.
- Initialization of readline_t with calloc
- Check malloc/calloc return
- Avoid possible free(NULL)
- Added some useful comments on test cases
- Clarify API on readme file and header comments
```
